### PR TITLE
Add sign_digest support and an example program

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,25 @@ ctest
 ```
 
 
-### Run the example app
+### Example program that signs the request digest with the C++ library, and places the order
 
 ```
-cd build/example
+cmake -DEOSIO_R1_KEY_ENABLE_TEST=ON -DEOSIO_R1_KEY_ENABLE_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Release -S. -Bbuild -DOPENSSL_ROOT_DIR=/usr/local && cmake --build build
 
-ecc_signing
+# follow https://api.exchange.bullish.com/docs/api/rest/#overview--get-your-bullish-account-id to prepare the environment variables
+export BX_API_HOSTNAME=...
+export BX_PUBLIC_KEY=...
+export BX_PRIVATE_KEY=...
+export BX_API_METADATA=...
+export BX_AUTHORIZER=...
+export BX_JWT=...
+
+# call the python tool which calls ./build/example/ecc_signing to sign
+./build/example/create_order.py
+
+# expected output like, confirming the order has been placed
+{"message":"Command acknowledged - CreateOrder","requestId":"511042106937573376","orderId":"511042106937573377","test":false}
+
 ```
 
 ## License

--- a/centos8.dockerfile
+++ b/centos8.dockerfile
@@ -1,0 +1,36 @@
+FROM centos:8
+#docker run -it -v /path/to/cpp-signer:/root centos:8 /bin/bash
+RUN cd /etc/yum.repos.d && \
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+RUN dnf update -y
+RUN dnf install -y cmake && \
+    dnf install -y gcc-toolset-10-gcc-c++ && \
+    dnf install -y git && \
+    dnf install -y perl && \
+    dnf install -y wget && \
+    dnf install -y zlib-devel
+
+RUN source scl_source enable gcc-toolset-10 && \
+    wget https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz && \
+    tar -xzvf openssl-1.1.1k.tar.gz && \
+    cd openssl-1.1.1k && \
+    ./config --prefix=/usr/local --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic && \
+    make && \
+    make install && \
+    cd ..
+
+COPY . cpp-signer
+
+RUN source scl_source enable gcc-toolset-10 && \
+    update-alternatives --install /usr/bin/c++ c++ /opt/rh/gcc-toolset-10/root/usr/bin/g++ 10 && \
+    export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64 && \
+    cd cpp-signer && \
+    cmake -DEOSIO_R1_KEY_ENABLE_TEST=ON -DEOSIO_R1_KEY_ENABLE_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Release -S. -Bbuild -DOPENSSL_ROOT_DIR=/usr/local && cmake --build build
+
+# python tool to generate JWT
+RUN git clone https://github.com/bullish-exchange/api-examples.git
+RUN dnf install -y python3-pip
+RUN cd api-examples && pip3 install -r requirements.txt
+

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,2 +1,4 @@
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/create_order.py ${CMAKE_CURRENT_BINARY_DIR}/create_order.py COPYONLY)
 add_executable(ecc_signing ecc_signing.cpp)
 target_link_libraries(ecc_signing PRIVATE eosio_r1_key)

--- a/example/create_order.py
+++ b/example/create_order.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+from datetime import datetime, timezone
+from hashlib import sha256
+import subprocess
+import requests
+
+for envvar in ["BX_API_HOSTNAME", "BX_PRIVATE_KEY", "BX_JWT", "BX_AUTHORIZER"]:
+    if os.getenv(envvar) is None:
+        print("ERROR: required environment variable is not set: ", envvar)
+        sys.exit(3)
+
+
+HOST_NAME = os.getenv("BX_API_HOSTNAME")
+PRIVATE_KEY = os.getenv("BX_PRIVATE_KEY")
+JWT_TOKEN = os.getenv("BX_JWT")
+AUTHORIZER = os.getenv("BX_AUTHORIZER")
+
+# C++ signer binary is in the same path as this python program
+CPP_SIGNER = os.path.join(os.path.dirname(__file__), 'ecc_signing')
+
+session = requests.Session()
+response = session.get(HOST_NAME + "/trading-api/v1/nonce", verify=False)
+nonce = json.loads(response.text)["lowerBound"]
+next_nonce = str(nonce + 1)
+timestamp = str(int(datetime.now(timezone.utc).timestamp() * 1000))
+
+body = {
+    "timestamp": timestamp,
+    "nonce": next_nonce,
+    "authorizer": AUTHORIZER,
+    "command": {
+        "commandType": "V1CreateOrder",
+        "handle": None,
+        "symbol": "BTCUSD",
+        "type": "LMT",
+        "side": "BUY",
+        "price": "30071.5000",
+        "stopPrice": None,
+        "quantity": "1.87000000",
+        "timeInForce": "GTC",
+        "allowMargin": False,
+    },
+}
+
+payload = (json.dumps(body, separators=(",", ":"))).encode("utf-8")
+digest = sha256(payload.rstrip()).hexdigest()
+
+# 1st way:
+# call the ecc_signing C++ program with sign with: private key, message digest
+result = subprocess.run([CPP_SIGNER, PRIVATE_KEY, digest], stdout=subprocess.PIPE)
+
+# 2nd way:
+# result = subprocess.run([CPP_SIGNER, PRIVATE_KEY, payload.rstrip()], stdout=subprocess.PIPE)
+
+cpp_signature = result.stdout.decode("utf-8").rstrip()
+
+print("cpp_signature:", cpp_signature)
+
+headers = {
+    "Content-type": "application/json",
+    "Authorization": f"Bearer {JWT_TOKEN}",
+    "BX-SIGNATURE": cpp_signature,
+    "BX-TIMESTAMP": timestamp,
+    "BX-NONCE": next_nonce,
+}
+
+print("headers:", headers)
+print("body:", body)
+
+response = session.post(
+    HOST_NAME + "/trading-api/v1/orders", json=body, headers=headers
+)
+print(f"HTTP Status: {response.status_code}, \n{response.text}")

--- a/example/ecc_signing.cpp
+++ b/example/ecc_signing.cpp
@@ -1,14 +1,32 @@
 #include <eosio/r1_key.hpp>
 #include <iostream>
 
-int main() {
+// Usage: ./ecc_signing [key] [payload or payload's sha256 digest]
+
+int main(int argc, char *argv[]) {
   OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
-  const char* test_json = R"x({"accountId":"abc","nonce":1,"expirationTime":1636755051,"biometricsUsed":false,"sessionKey":null})x";
-  
+
+  std::string test_json{R"x({"accountId":"abc","nonce":1,"expirationTime":1636755051,"biometricsUsed":false,"sessionKey":null})x"};
   // The private key in this example is coded into the source. In production settings please store the private key in an environment variable and retrieve it here
-  eosio::r1::private_key priv_key{"PVT_R1_iyQmnyPEGvFd8uffnk152WC2WryBjgTrg22fXQryuGL9mU6qW"};
-  
-  std::cout << priv_key.sign(test_json)<< "\n";
-  
+  std::string test_key{"PVT_R1_iyQmnyPEGvFd8uffnk152WC2WryBjgTrg22fXQryuGL9mU6qW"};
+
+  std::string key = test_key;
+  std::string payload = test_json;
+
+  if (argc >= 3) {
+    key = argv[1];
+    payload = argv[2];
+  }
+
+  eosio::r1::private_key priv_key{key};
+
+  if (payload[0] == '{') {
+    // input is the payload message
+    std::cout << priv_key.sign(payload) << "\n";
+  } else {
+    // input is the hex string of the payload message's sha256 checksum
+    std::cout << priv_key.sign_digest(payload) << "\n";
+  }
+
   return 0;
 }

--- a/include/eosio/r1_key.hpp
+++ b/include/eosio/r1_key.hpp
@@ -72,6 +72,7 @@ public:
 
   ecc_signature sign_compact(const eosio::checksum256 &digest) const;
   std::string sign(std::string_view input) const;
+  std::string sign_digest(std::string_view digest) const;
 
   static private_key generate();
   ecc_private_key serialize() const;

--- a/tests/sign_test.cpp
+++ b/tests/sign_test.cpp
@@ -11,12 +11,12 @@ eosio::checksum256 hash(std::string_view str);
 
 bool verify_signing(const eosio::r1::private_key &priv_key, const char *txt,
                     int i) {
-  auto pub_key = priv_key.get_public_key();
-  auto signature_txt = priv_key.sign(txt);
+  auto pub_key = priv_key.get_public_key(); // derived public key from the private key
+  auto signature_txt = priv_key.sign(txt); // sign the payload message
   auto signature = eosio::signature_from_string(signature_txt);
   auto ecc_sig = std::get<1>(signature);
   auto pub_key_from_signature =
-      eosio::r1::public_key(ecc_sig, eosio::sha256::hash(txt));
+      eosio::r1::public_key(ecc_sig, eosio::sha256::hash(txt)); // recover public key from the signature
 
   if (pub_key.serialize() != pub_key_from_signature.serialize()) {
     std::cerr << "public key from signature does not match the one from "
@@ -41,15 +41,76 @@ bool verify_signing(const eosio::r1::private_key &priv_key, const char *txt,
   return true;
 }
 
+
+bool verify_signing_digest(const eosio::r1::private_key &priv_key, const char *txt, const char *digest, int i) {
+  auto pub_key = priv_key.get_public_key(); // derived public key from the private key
+  auto signature_txt = priv_key.sign_digest(digest); // sign the payload message's digest
+  auto signature = eosio::signature_from_string(signature_txt);
+  auto ecc_sig = std::get<1>(signature);
+  auto pub_key_from_signature =
+      eosio::r1::public_key(ecc_sig, eosio::sha256::hash(txt)); // recover public key from the signature
+
+  if (pub_key.serialize() != pub_key_from_signature.serialize()) {
+    std::cerr << "public key from signature from digest does not match the one from "
+                 "private key, iteration "
+              << i << "\n"
+              << "  private_key              : "
+              << eosio::private_key_to_string(eosio::private_key{
+                  std::in_place_index<1>, priv_key.serialize()})
+              << "\n"
+              << "  public_key               : "
+              << eosio::public_key_to_string(eosio::public_key{
+                  std::in_place_index<1>, pub_key.serialize()})
+              << "\n"
+              << "  public_key from signature: "
+              << eosio::public_key_to_string(
+                  eosio::public_key{std::in_place_index<1>,
+                                    pub_key_from_signature.serialize()})
+              << "\n"
+              << "  signature                : " << signature_txt << "\n";
+    return false;
+  }
+  return true;
+}
+
+template<typename CharT>
+static std::string to_hex(const CharT* d, uint32_t s) {
+  std::string r;
+  const char* to_hex="0123456789abcdef";
+  uint8_t* c = (uint8_t*)d;
+  for( uint32_t i = 0; i < s; ++i ) {
+    (r += to_hex[(c[i] >> 4)]) += to_hex[(c[i] & 0x0f)];
+  }
+  return r;
+}
+
+std::string checksum_to_str(const eosio::checksum256& checksum) {
+  return to_hex(checksum.data(), checksum.extract_as_byte_array().size());
+}
+
 int main() {
   OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
+  // test payload test_json
   const char *test_json =
       R"x({"accountId":"abc","nonce":1,"expirationTime":1636755051,"biometricsUsed":false,"sessionKey":null})x";
 
+  // sha256 digest hex string of the test payload
+  const char *test_json_sha = "3a553834f0aae08f8b3f7e85777f9334f772971777d3d06e2b3aced27b0c203d";
+
+  // sign payload
   for (int i = 0; i < 100; ++i) {
     eosio::r1::private_key priv_key(
         "PVT_R1_23o8wEtWV2AayohHfm5C8K84jyZiKKbo3de6fGffQNVBWjEEJ4");
     if (!verify_signing(priv_key, test_json, i))
+      return 1;
+  }
+
+  // sign the sha256 digest hex string of the payload
+  for (int i = 0; i < 100; ++i) {
+    eosio::r1::private_key priv_key(
+        "PVT_R1_23o8wEtWV2AayohHfm5C8K84jyZiKKbo3de6fGffQNVBWjEEJ4");
+    if (!verify_signing_digest(priv_key, test_json, test_json_sha, i))
       return 1;
   }
   return 0;


### PR DESCRIPTION
This PR adds new function support and example programs.

## New library function for signing with digest

Added `sign_digest` library function for generating the signature from the digest of the payload message.

```
std::string private_key::sign_digest(std::string_view digest);
```

## Test case and example C++ code

`tests/sign_test.cpp` contains test cases and usage examples.

```
  // test payload test_json
  const char *test_json =
      R"x({"accountId":"abc","nonce":1,"expirationTime":1636755051,"biometricsUsed":false,"sessionKey":null})x";

  // sha256 digest hex string of the test payload
  const char *test_json_sha = "3a553834f0aae08f8b3f7e85777f9334f772971777d3d06e2b3aced27b0c203d";
```

`sign(test_json)` and `sign_digest(test_json_sha)` will both generate valid signatures (usually different, standard ECDSA signatures are non-deterministic in nature).

## Example usage with order placing

Build

```
cmake -DEOSIO_R1_KEY_ENABLE_TEST=ON -DEOSIO_R1_KEY_ENABLE_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Release -S. -Bbuild -DOPENSSL_ROOT_DIR=/usr/local && cmake --build build
```

Set up credentials and place the order

```
# please follow https://api.exchange.bullish.com/docs/api/rest/#servers to generate those for the testing account.
export BX_API_HOSTNAME=...
export BX_PUBLIC_KEY=...
export BX_PRIVATE_KEY=...
export BX_API_METADATA=...
export BX_AUTHORIZER=...
export BX_JWT=...

# call the python tool which calls ./build/example/ecc_signing to sign
./build/example/create_order.py
```

Example output, confirming the order has been placed:

```
{"message":"Command acknowledged - CreateOrder","requestId":"511042106937573376","orderId":"511042106937573377","test":false}
```
