### PR TITLE
Add custody API call example calling the C++ signing library through a Python program

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libraries/abieos"]
+	path = libraries/abieos
+	url = https://github.com/EOSIO/abieos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-include(FetchContent)
-
 cmake_minimum_required (VERSION 3.10)
 
 # This is your project statement. You should always list languages;
@@ -16,14 +14,7 @@ endif()
 find_package(OpenSSL 1.1 REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 
-set(ABIEOS_BUILD_SHARED_LIB OFF)
-FetchContent_Declare(
-  abieos
-  GIT_REPOSITORY https://github.com/EOSIO/abieos.git
-  GIT_TAG 92920886a9c8606fbda5bbdca41365f4e617e37e
-)
-FetchContent_MakeAvailable(abieos)
-
+add_subdirectory(libraries)
 add_subdirectory(src)
 
 option(EOSIO_R1_KEY_ENABLE_TEST "Enable building test" OFF)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
-# eosio-signing-example
+# C++ library and examples for signing messages or digests using R1 keys
 
 This repo provides the library and minimal C++ code example to sign any arbitrary message with an EOSIO R1 key and produce an EOSIO signature (k1 keys are not yet supported).
 
-to compile:
+Make sure the submodules are pulled before compiling it.
+
+```
+git submodule update --init --recursive
+```
+
+To build the project:
+
 ```
 cmake -DCMAKE_BUILD_TYPE=Release -S. -Bbuild && cmake --build build
 ```
 
-
 ## How to - integration into your own project
+
+Add this repo as a submodule, such as in `cpp-signer`.
 
 In your CMakeLists.txt 
 
@@ -23,13 +31,7 @@ project(
 
 set(CMAKE_CXX_STANDARD 17)
 
-### TODO: change to following GIT_TAG value to the appropriate commit hash
-FetchContent_Declare(
-  eosio_r1_key
-  GIT_REPOSITORY https://github.com/b1-as/eosio-signing-example
-  GIT_TAG e579075b714a1a3bd40436dcb29c575ddd83859b
-)
-FetchContent_MakeAvailable(eosio_r1_key)
+add_subdirectory(cpp-signer)
 
 add_executable(mysrc mysrc.cpp)
 target_link_libraries(mysrc PRIVATE eosio_r1_key)
@@ -44,19 +46,19 @@ In your C++ source code `mysrc.cpp`
 int main() {
   OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
   const char* test_json = R"x({"accountId":"abc","nonce":1,"expirationTime":1636755051,"biometricsUsed":false,"sessionKey":null})x";
-  
+
   // The private key in this example is coded into the source. In production settings please store the private key in an environment variable and retrieve it here
   eosio::r1::private_key priv_key{"PVT_R1_iyQmnyPEGvFd8uffnk152WC2WryBjgTrg22fXQryuGL9mU6qW"};
-  
+
   std::cout << priv_key.sign(test_json)<< "\n";
-  
+
   return 0;
 }
 ```
 
-## For CentOS 7 
+## For CentOS 7
 
-Requires C++17 support. We have tested with g++ 10.2.1 
+Requires C++17 support. We have tested with g++ 10.2.1
 ```
 # g++ --version
 g++ (GCC) 10.2.1 20210130 (Red Hat 10.2.1-11)
@@ -70,15 +72,16 @@ CentOS Linux release 7.9.2009 (Core)
 
 
 ### Install openssl
-The system default OpenSSL package won't work. Please install latest OpenSSL 1.1 from source and install it to `/usr/local`. 
+The system default OpenSSL package won't work. Please install latest OpenSSL 1.1 from source and install it to `/usr/local`.
 
-when buiding openssl 1.1
+As of this writing, OpenSSL version 1.1.1q is current and has no vulnerabilities. Please check the OpenSSL [**vulnerabilities page**](https://www.openssl.org/news/vulnerabilities.html) for the latest, safest 1.1 version and substitute that in below when building.
+
 ```
-wget https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz
+wget https://ftp.openssl.org/source/openssl-1.1.1q.tar.gz
 
-tar -xzvf openssl-1.1.1k.tar.gz
+tar -xzvf openssl-1.1.1q.tar.gz
 
-cd openssl-1.1.1k
+cd openssl-1.1.1q
 
 ./config --prefix=/usr/local --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic
 

--- a/centos8.dockerfile
+++ b/centos8.dockerfile
@@ -13,9 +13,9 @@ RUN dnf install -y cmake && \
     dnf install -y zlib-devel
 
 RUN source scl_source enable gcc-toolset-10 && \
-    wget https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz && \
-    tar -xzvf openssl-1.1.1k.tar.gz && \
-    cd openssl-1.1.1k && \
+    wget https://ftp.openssl.org/source/openssl-1.1.1q.tar.gz && \
+    tar -xzvf openssl-1.1.1q.tar.gz && \
+    cd openssl-1.1.1q && \
     ./config --prefix=/usr/local --openssldir=/etc/ssl --libdir=lib no-shared zlib-dynamic && \
     make && \
     make install && \

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,5 @@
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/create_order.py ${CMAKE_CURRENT_BINARY_DIR}/create_order.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/api_withdraw_crypto_endpoints.py ${CMAKE_CURRENT_BINARY_DIR}/api_withdraw_crypto_endpoints.py COPYONLY)
 add_executable(ecc_signing ecc_signing.cpp)
 target_link_libraries(ecc_signing PRIVATE eosio_r1_key)

--- a/example/api_withdraw_crypto_endpoints.py
+++ b/example/api_withdraw_crypto_endpoints.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+
+'''
+A Python example program for withdraw by signing digest through C++ program.
+
+Build the C++ program with the cpp-signer library.
+
+    $ cmake -DEOSIO_R1_KEY_ENABLE_TEST=ON -DEOSIO_R1_KEY_ENABLE_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Release -S. -Bbuild -DOPENSSL_ROOT_DIR=/usr/local && cmake --build build
+
+Set the environments accordingly
+
+    export BX_API_HOSTNAME=...
+    export BX_PRIVATE_KEY=...
+    export BX_API_METADATA=...
+
+Run the Python example program
+
+    $ ./build/example/api_withdraw_crypto_endpoints.py [withdraw body JSON string]
+
+Example output
+
+    ...
+    $ ./build/example/api_withdraw_crypto_endpoints.py
+
+    ***** LOGIN *******
+    ...
+    ***** WITHDRAWAL CHALLENGE *******
+    ...
+    ***** WITHDRAWAL ASSERTION *******
+    ...
+    JSON Response to Assertion: {'statusReason': 'Withdrawal assertion accepted', 'statusReasonCode': 1001, 'custodyTransactionId': 'DB:FW_6f15d9427f3b5a00c141faaa160584ae74db80bce0ae57cf7d856e9e57892174'}
+
+'''
+
+import base64
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from hashlib import sha256
+
+import requests
+import subprocess
+
+
+HOST_NAME = os.getenv("BX_API_HOSTNAME")
+PRIVATE_KEY = os.getenv("BX_PRIVATE_KEY")
+ENCODED_METADATA = os.getenv("BX_API_METADATA")
+
+# C++ signer binary is in the same path as this python program
+CPP_SIGNER = os.path.join(os.path.dirname(__file__), 'ecc_signing')
+
+
+# Sign the digest with the C++ signer binary that calls the cpp-signer library
+def sign_digest_with_cpp_lib(digest):
+    global PRIVATE_KEY, CPP_SIGNER
+    result = subprocess.run([CPP_SIGNER, PRIVATE_KEY, digest], stdout=subprocess.PIPE)
+    signature = result.stdout.decode("utf-8").rstrip()
+    return signature
+
+
+# Example withdrawBody
+withdrawBody = {
+    "nonce" : "123578",
+    "command" : {
+        "commandType": "V1WithdrawalChallenge",
+        "destinationId": "d8f79f38322c9de0b00b02bca20a307570a9d6f96179efee4068208b49f5ebd8",   #hash id
+        "network": "SWIFT",
+        "symbol": "USD",
+        "quantity": "5"
+    }
+}
+
+# if provided, use the argv[1] as the withdrawBody
+if len(sys.argv) > 1:
+    withdrawBody = sys.argv[1]
+
+
+session = requests.Session()
+metadata = base64.b64decode(ENCODED_METADATA)
+print( f"MetaData: {metadata}")
+account_id = str(json.loads(metadata)["accountId"])
+
+PUBLIC_KEY = json.loads(metadata)["publicKey"]
+print( f"Public Key: {PUBLIC_KEY}");
+
+"""
+LOGIN using standard Bullish trading-api mechanism
+"""
+print( "\n\n\n\n***** LOGIN *******\n")
+
+timestamp = int(datetime.now(timezone.utc).timestamp())
+expiration_time = int(timestamp + 300)
+login_payload = {
+    "accountId": account_id,
+    "nonce": timestamp,
+    "expirationTime": expiration_time,
+    "biometricsUsed": False,
+    "sessionKey": None,
+}
+
+payload = (json.dumps(login_payload, separators=(",", ":"))).encode("utf-8")
+digest = sha256(payload.rstrip()).hexdigest()
+
+signature = sign_digest_with_cpp_lib(digest)
+
+print(f"Login digest: {digest}");
+print(f"Login signature: {signature}");
+
+headers = {
+    "Content-type": "application/json"
+}
+body = {
+    "publicKey": PUBLIC_KEY,
+    "signature": signature,
+    "loginPayload": login_payload,
+}
+
+print( f"body to be sent: {body}")
+
+response = session.post(
+    HOST_NAME + "/trading-api/v1/users/login",
+    json=body,
+    headers=headers,
+    verify=True
+)
+print(f"HTTP Status: {response.status_code}")
+
+
+responseJson = response.json()
+
+print(f"JSON Response: {responseJson}")
+
+print( "Token:")
+print( f"{responseJson['token']}")
+
+"""
+Request a withdrawal challenge
+"""
+
+print( "\n\n\n\n***** WITHDRAWAL CHALLENGE *******\n")
+# Attempt a withdrawal directly to ccqs on portforwarding
+withdrawHeaders = {
+  "Content-type": "application/json",
+  "Authorization" : "Bearer " + responseJson['token']
+}
+
+print(f"About to send withdrawal challenge request to CCQS locally");
+
+withdrawChallengeResponse = requests.Session().post(
+    HOST_NAME+"/trading-api/v1/wallets/withdrawal-challenge",
+    headers = withdrawHeaders,
+    json=withdrawBody,
+    verify=True
+)
+
+withdrawalJson = withdrawChallengeResponse.json();
+print(f"JSON Response to Challenge Request: {withdrawalJson}")
+challenge = withdrawalJson['challenge'];
+
+print(challenge);
+
+"""
+Sign the challenge and send back to effect the withdrawal
+"""
+print( "\n\n\n\n***** WITHDRAWAL ASSERTION *******\n")
+
+signature = sign_digest_with_cpp_lib(challenge)
+print(signature);
+
+withdrawAssertion = {
+    "command" : {
+        "commandType" : "V1WithdrawalAssertion",
+        "signature": signature,
+        "challenge": challenge,
+        "publicKey": PUBLIC_KEY
+    }
+}
+
+withdrawAssertionResponse = requests.Session().post(
+    HOST_NAME+"/trading-api/v1/wallets/withdrawal-assertion",
+    headers=withdrawHeaders,
+    json=withdrawAssertion,
+    verify=True
+)
+
+withdrawalAssertionResponseJson = withdrawAssertionResponse.json();
+print( f"JSON Response to Assertion: {withdrawalAssertionResponseJson}");

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+add_subdirectory(abieos)


### PR DESCRIPTION
A Python example program for withdraw by signing digest through C++ program.

Build the C++ program with the cpp-signer library.

```
$ cmake -DEOSIO_R1_KEY_ENABLE_TEST=ON -DEOSIO_R1_KEY_ENABLE_EXAMPLE=ON -DCMAKE_BUILD_TYPE=Release -S. -Bbuild -DOPENSSL_ROOT_DIR=/usr/local && cmake --build build
```

Set the environments accordingly (ref: https://github.com/bullish-exchange/api-examples )

```
export BX_API_HOSTNAME=...
export BX_PRIVATE_KEY=...
export BX_API_METADATA=...
```

Run the Python example program

```
$ ./build/example/api_withdraw_crypto_endpoints.py
```

Example output

```
...
***** LOGIN *******
...
***** WITHDRAWAL CHALLENGE *******
...
***** WITHDRAWAL ASSERTION *******
...
JSON Response to Assertion: {'statusReason': 'Withdrawal assertion accepted', 'statusReasonCode': 1001, 'custodyTransactionId': 'DB:FW_6f15d9427f3b5a00c141faaa160584ae74db80bce0ae57cf7d856e9e57892174'}
```
