### PR TITLE
Add a C++ example program to create orders via order entry API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+.cache
+.vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -136,11 +136,13 @@ export BX_JWT=...
 
 ```
 
-# C++ Example for Withdraw API Calls
+# C++ Examples
+
+## Call with Withdraw API
 
 This repo provides an example C++ program using the cpp-signer library to sign requests to perform withdraw Custody API calls.
 
-Note: the withdrawal request body contains a hash ID. For different testing accounts, please use the corresponding hash IDs for the destinations.   
+Note: the withdrawal request body contains a hash ID. For different testing accounts, please use the corresponding hash IDs for the destinations.
 
 To run the build program:
 
@@ -195,6 +197,56 @@ One example output:
 % Sending HTTP request with body: {"command":{"commandType":"V1WithdrawalAssertion","signature":"SIG_R1_KBf2suQydKkfNBBR5jmtYjUo2KKXtp8kYuV1TPGrs31LnnwBT7CJtt7HPmdUDExRaAtBYYFiqacW7zvF3sffTPuti8r4wA","challenge":"755b8c0a147f2b3735d7c90869d5cf2d41025aa20b245671bcf3098e071e06a2","publicKey":"PUB_R1_7c5WYcQ6aSXFTwTUtMcEXFjZtbjbDumCeNr7oYDSBF7xuqpDV3"}}
 % Received HTTP response status code: 200
 % Received HTTP response body: {"statusReason":"Withdrawal assertion accepted","statusReasonCode":1001,"custodyTransactionId":"DB:FW_0c4c220c545ed1c0f54c918b2141c79f23ea866f64853c805b27b9f1fd61a6c2"}
+```
+
+## Call with Orders API
+
+To run the build program:
+
+```
+# Set the environments accordingly, following https://github.com/bullish-exchange/api-examples
+
+export BX_API_HOSTNAME=...
+export BX_PRIVATE_KEY=...
+export BX_JWT=...
+export BX_AUTHORIZER=...
+```
+
+Run the `create_order` program to place the orders request:
+
+One example output:
+
+```
+=== STEP 0. Load Environment Variables =============================================================
+
+% Loaded BX_API_HOSTNAME: https://api.simnext.bullish-test.com
+% Loaded BX_PRIVATE_KEY: [--- HIDDEN ---]
+% Loaded BX_JWT: [--- HIDDEN ---]
+% Loaded BX_AUTHORIZER: C3FE2367E8C90000823E000000000000
+
+=== STEP 1. Get Nonce ==============================================================================
+
+% Sending HTTP request to: https://api.simnext.bullish-test.com/trading-api/v1/nonce
+% Received HTTP response status code: 200
+% Received HTTP response reason: OK
+% Received HTTP response body: {"lowerBound":1671408000000000,"upperBound":1671494399999000}
+% Nonce: 1671408000000001
+
+=== STEP 2. Create Order ===========================================================================
+
+% Signature: SIG_R1_JviKVowMYNVE3Z1c4q58a6c96VoqVEqfGLERZGSaajoB36X3Ln4ftFkWncqpKMsdhGPvXcDdtC1mG2qnSSp8Ztceid1TXV
+% Sending HTTP request to: https://api.simnext.bullish-test.com/trading-api/v1/orders
+% Sending HTTP request with headers:
+--- Headers -----
+Authorization: [--- HIDDEN ---]
+BX-NONCE: 1671408000000001
+BX-SIGNATURE: SIG_R1_JviKVowMYNVE3Z1c4q58a6c96VoqVEqfGLERZGSaajoB36X3Ln4ftFkWncqpKMsdhGPvXcDdtC1mG2qnSSp8Ztceid1TXV
+BX-TIMESTAMP: 1671416287000
+-----------------
+% Sending HTTP request with body: {"timestamp":"1671416287000","nonce":"1671408000000001","authorizer":"C3FE2367E8C90000823E000000000000","command":{"commandType":"V1CreateOrder","handle":null,"symbol":"BTCUSD","type":"LMT","side":"BUY","price":"30071.5000","stopPrice":null,"quantity":"1.87000000","timeInForce":"GTC","allowMargin":false}}
+% Received HTTP response status code: 200
+% Received HTTP response reason: OK
+% Received HTTP response body: {"message":"Command acknowledged - CreateOrder","requestId":"524772390270926848","orderId":"524772390270926849","test":false}```
 ```
 
 ## License

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,34 +1,27 @@
-
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/create_order.py ${CMAKE_CURRENT_BINARY_DIR}/create_order.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/api_withdraw_crypto_endpoints.py ${CMAKE_CURRENT_BINARY_DIR}/api_withdraw_crypto_endpoints.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/create_order.py ${CMAKE_CURRENT_BINARY_DIR}/create_order.py COPYONLY)
 
+add_executable(create_order create_order.cpp)
 add_executable(ecc_signing ecc_signing.cpp)
-
 add_executable(withdraw withdraw.cpp)
 
-target_link_libraries(ecc_signing PRIVATE eosio_r1_key)
-
-
-include_directories(include)
-include_directories(include/rapidjson/include)
-
+find_package(Boost 1.71.0 COMPONENTS *boost libraries here*)
 find_package(OpenSSL REQUIRED)
 if(OPENSSL_FOUND)
     set(HTTPLIB_IS_USING_OPENSSL TRUE)
 endif()
 
-target_link_libraries(withdraw PUBLIC
-        $<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::SSL>
-        $<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::Crypto>)
-
-target_compile_definitions(withdraw PUBLIC
-        $<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:CPPHTTPLIB_OPENSSL_SUPPORT>
-        )
-
-target_link_libraries(withdraw PRIVATE eosio_r1_key)
-
-find_package(Boost 1.71.0 COMPONENTS *boost libraries here*)
+include_directories(include)
+include_directories(include/rapidjson/include)
 include_directories(${Boost_INCLUDE_DIRS})
+
+target_compile_definitions(create_order PUBLIC $<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:CPPHTTPLIB_OPENSSL_SUPPORT> )
+target_compile_definitions(withdraw PUBLIC $<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:CPPHTTPLIB_OPENSSL_SUPPORT> )
+
+target_link_libraries(create_order ${Boost_LIBRARIES})
+target_link_libraries(create_order PRIVATE eosio_r1_key)
+target_link_libraries(create_order PUBLIC $<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::SSL> $<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::Crypto>)
+target_link_libraries(ecc_signing PRIVATE eosio_r1_key)
 target_link_libraries(withdraw ${Boost_LIBRARIES})
-
-
+target_link_libraries(withdraw PRIVATE eosio_r1_key)
+target_link_libraries(withdraw PUBLIC $<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::SSL> $<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::Crypto>)

--- a/example/create_order.cpp
+++ b/example/create_order.cpp
@@ -1,0 +1,194 @@
+#include "httplib/httplib.h"
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+#include <eosio/r1_key.hpp>
+
+#include <boost/beast/core/detail/base64.hpp>
+
+#include <cstdlib>
+#include <ctime>
+#include <iostream>
+#include <string>
+
+struct Env {
+  std::string hostname;
+  std::string private_key;
+  std::string jwt_token;
+  std::string authorizer;
+};
+
+bool getenv(std::string &str, const char *name) {
+  if (const char *p = std::getenv(name)) {
+    str.assign(p);
+    return true;
+  }
+  std::cerr << "Error: Variable \"" << name << "\" not set in the environment."
+            << std::endl;
+  return false;
+}
+
+bool load_env(Env &env) {
+  return getenv(env.hostname, "BX_API_HOSTNAME") &&
+         getenv(env.private_key, "BX_PRIVATE_KEY") &&
+         getenv(env.jwt_token, "BX_JWT") &&
+         getenv(env.authorizer, "BX_AUTHORIZER");
+}
+
+bool check_key_u64(const rapidjson::Document &d, const char *key) {
+  if (!d.HasMember(key)) {
+    std::cerr << "Error: Key \"" << key << "\" not found in JSON string."
+              << std::endl;
+    return false;
+  }
+  if (!d[key].IsUint64()) {
+    std::cerr << "Error: Key \"" << key
+              << "\" found in JSON string "
+                 "but its value is not an unsigned 64-bit integer."
+              << std::endl;
+    return false;
+  }
+  return true;
+}
+
+bool load_u64(uint64_t &u64, const char *key, const char *json) {
+  rapidjson::Document d;
+  d.Parse(json);
+  if (!check_key_u64(d, key)) {
+    return false;
+  }
+  u64 = d[key].GetUint64();
+  return true;
+}
+
+uint64_t get_time_now_u64() {
+  // return number of seconds since epoch (1 Jan 1970 UTC)
+  // e.g. return 1669796089;
+  return static_cast<uint64_t>(std::time(nullptr));
+}
+
+void print_step(const std::string &step) {
+  std::cout << "\n=== STEP " + step + " " + std::string(90 - step.size(), '=')
+            << "\n"
+            << std::endl;
+}
+
+std::string headers_to_string(const httplib::Headers &headers) {
+  std::ostringstream oss;
+  oss << "\n--- Headers -----\n";
+  for (const std::pair<std::string, std::string> &pa : headers) {
+    if (pa.first == "Authorization") {
+      oss << pa.first << ": [--- HIDDEN ---]" << std::endl;
+    } else {
+      oss << pa.first << ": " << pa.second << std::endl;
+    }
+  }
+  oss << "-----------------\n";
+  return oss.str();
+}
+
+void print_request(const std::string &addr, const std::string &body = "",
+                   const httplib::Headers &headers = httplib::Headers{}) {
+  std::cout << "% Sending HTTP request to: " << addr << std::endl;
+  if (!headers.empty()) {
+    std::cout << "% Sending HTTP request with headers: "
+              << headers_to_string(headers);
+  }
+  if (!body.empty()) {
+    std::cout << "% Sending HTTP request with body: " << body << std::endl;
+  }
+}
+
+void print_response(const httplib::Result &res) {
+  std::cout << "% Received HTTP response status code: " << res->status
+            << std::endl;
+  std::cout << "% Received HTTP response reason: " << res->reason << std::endl;
+  std::cout << "% Received HTTP response body: " << res->body << std::endl;
+}
+
+int main() {
+  OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+
+  // STEP 0. Load Environment Variables
+  print_step("0. Load Environment Variables");
+
+  Env env;
+  if (!load_env(env)) {
+    std::cerr << "Please make sure the environment variables have been set:\n"
+                 "  - BX_API_HOSTNAME\n"
+                 "  - BX_PRIVATE_KEY\n"
+                 "  - BX_JWT\n"
+                 "  - BX_AUTHORIZER\n"
+              << std::endl;
+    ;
+    return 1;
+  }
+
+  std::string hidden = "[--- HIDDEN ---]";
+  std::cout << "% Loaded BX_API_HOSTNAME: " << env.hostname << std::endl;
+  std::cout << "% Loaded BX_PRIVATE_KEY: " << hidden << std::endl;
+  std::cout << "% Loaded BX_JWT: " << hidden << std::endl;
+  std::cout << "% Loaded BX_AUTHORIZER: " << env.authorizer << std::endl;
+
+  // STEP 1. Get Nonce
+  print_step("1. Get Nonce");
+  httplib::Client cli(env.hostname);
+  std::string path;
+  std::string body;
+  std::string signature;
+  path = "/trading-api/v1/nonce";
+  httplib::Result res = cli.Get(path);
+  print_request(env.hostname + path);
+  print_response(res);
+  uint64_t nonce_u64;
+  if (!load_u64(nonce_u64, "lowerBound", res->body.c_str())) {
+    std::cerr << "Error: Cannot load lowerBound of nonce from HTTP response."
+              << std::endl;
+    return 1;
+  }
+  nonce_u64 += 1;
+  std::cout << "% Nonce: " << nonce_u64 << std::endl;
+  std::string nonce = std::to_string(nonce_u64);
+
+  // STEP 2. Create Order
+  print_step("2. Create Order");
+  uint64_t timestamp_u64 = get_time_now_u64();
+  std::string timestamp = std::to_string(timestamp_u64) + "000";
+  body = "{"
+         "\"timestamp\":\"" +
+         timestamp +
+         "\","
+         "\"nonce\":\"" +
+         nonce +
+         "\","
+         "\"authorizer\":\"" +
+         env.authorizer +
+         "\","
+         "\"command\":{"
+         "\"commandType\":\"V1CreateOrder\","
+         "\"handle\":null,"
+         "\"symbol\":\"BTCUSD\","
+         "\"type\":\"LMT\","
+         "\"side\":\"BUY\","
+         "\"price\":\"30071.5000\","
+         "\"stopPrice\":null,"
+         "\"quantity\":\"1.87000000\","
+         "\"timeInForce\":\"GTC\","
+         "\"allowMargin\":false"
+         "}"
+         "}";
+  eosio::r1::private_key priv_key{env.private_key};
+  signature = priv_key.sign(body);
+  std::cout << "% Signature: " << signature << std::endl;
+  httplib::Headers headers = {{"Authorization", "Bearer " + env.jwt_token},
+                              {"BX-SIGNATURE", signature},
+                              {"BX-TIMESTAMP", timestamp},
+                              {"BX-NONCE", nonce}};
+  path = "/trading-api/v1/orders";
+  print_request(env.hostname + path, body, headers);
+  std::string content_type = "application/json";
+  res = cli.Post(path, headers, body, content_type);
+  print_response(res);
+  return 0;
+}

--- a/example/withdraw.cpp
+++ b/example/withdraw.cpp
@@ -91,7 +91,7 @@ int main() {
 
   Env env;
   if (!load_env(env)) {
-    std::cerr << "Please make sure the enviornment variables have been set:\n"
+    std::cerr << "Please make sure the environment variables have been set:\n"
                   "  - BX_API_HOSTNAME\n"
                   "  - BX_PRIVATE_KEY\n"
                   "  - BX_API_METADATA" << std::endl;;


### PR DESCRIPTION
This PR adds a C++ example program to create orders via the order entry API.

The program is at `example/create_order.cpp`. It replicates the behavior of the `create_order.py` in the same directory. It is run by `example/create_order`. An example output (as in the `README.md`) is 

```
=== STEP 0. Load Environment Variables =============================================================

% Loaded BX_API_HOSTNAME: https://api.simnext.bullish-test.com
% Loaded BX_PRIVATE_KEY: [--- HIDDEN ---]
% Loaded BX_JWT: [--- HIDDEN ---]
% Loaded BX_AUTHORIZER: C3FE2367E8C90000823E000000000000

=== STEP 1. Get Nonce ==============================================================================

% Sending HTTP request to: https://api.simnext.bullish-test.com/trading-api/v1/nonce
% Received HTTP response status code: 200
% Received HTTP response reason: OK
% Received HTTP response body: {"lowerBound":1671408000000000,"upperBound":1671494399999000}
% Nonce: 1671408000000001

=== STEP 2. Create Order ===========================================================================

% Signature: SIG_R1_JviKVowMYNVE3Z1c4q58a6c96VoqVEqfGLERZGSaajoB36X3Ln4ftFkWncqpKMsdhGPvXcDdtC1mG2qnSSp8Ztceid1TXV
% Sending HTTP request to: https://api.simnext.bullish-test.com/trading-api/v1/orders
% Sending HTTP request with headers:
--- Headers -----
Authorization: [--- HIDDEN ---]
BX-NONCE: 1671408000000001
BX-SIGNATURE: SIG_R1_JviKVowMYNVE3Z1c4q58a6c96VoqVEqfGLERZGSaajoB36X3Ln4ftFkWncqpKMsdhGPvXcDdtC1mG2qnSSp8Ztceid1TXV
BX-TIMESTAMP: 1671416287000
-----------------
% Sending HTTP request with body: {"timestamp":"1671416287000","nonce":"1671408000000001","authorizer":"C3FE2367E8C90000823E000000000000","command":{"commandType":"V1CreateOrder","handle":null,"symbol":"BTCUSD","type":"LMT","side":"BUY","price":"30071.5000","stopPrice":null,"quantity":"1.87000000","timeInForce":"GTC","allowMargin":false}}
% Received HTTP response status code: 200
% Received HTTP response reason: OK
% Received HTTP response body: {"message":"Command acknowledged - CreateOrder","requestId":"524772390270926848","orderId":"524772390270926849","test":false}```
```

---

Meanwhile, in this PR we also

1. Add a `.gitignore` file
2. Fix a typo in `example/withdraw.cpp`.



